### PR TITLE
Sim 2898 on action complete

### DIFF
--- a/python/demos/character_commands.py
+++ b/python/demos/character_commands.py
@@ -167,7 +167,7 @@ class FocusCharacter(Demo):
         tick_count = 0
 
         # Focus on and follow the character at simulation start
-        async def on_ready(_):
+        async def on_ready(_) -> bool:
             nonlocal persona_id
             persona_list = await get_persona_list(bridge)
             persona_id = await choose_from_list("Enter persona id", persona_list)
@@ -217,7 +217,7 @@ class OverrideCharacterAction(Demo):
             https://github.com/fablestudio/thistle-gulch/blob/main/python/demos/character_commands.py
         """
 
-        async def on_ready(_):
+        async def on_ready(_) -> bool:
 
             persona_list = await get_persona_list(bridge)
             persona_id = await choose_from_list("Enter persona id", persona_list)
@@ -282,7 +282,7 @@ class RobBankAndArrestCriminal(Demo):
         arrest_triggered = False
         arrest_time: datetime
 
-        async def on_ready(_):
+        async def on_ready(_) -> bool:
             nonlocal robber_id, arrest_time
             persona_list = await get_persona_list(bridge)
             # Choose the persona to rob the bank, excluding the sheriff since he will arrest the robber.
@@ -382,7 +382,7 @@ class CustomConversation(Demo):
             https://github.com/fablestudio/thistle-gulch/blob/main/python/demos/character_commands.py
         """
 
-        async def on_ready(_):
+        async def on_ready(_) -> bool:
             personas = await get_persona_list(bridge)
             speaker_1_id = await choose_from_list(
                 "Enter speaker 1 id", options=personas
@@ -428,6 +428,8 @@ class CustomConversation(Demo):
 
             print(f"Following {speaker_1_id} with the camera")
             await bridge.runtime.api.follow_character(speaker_1_id, 0.8)
+
+            return True
 
         print("Registering custom on_ready callback.")
         bridge.on_ready = on_ready

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -62,7 +62,7 @@ class DefaultSagaServerDemo(Demo):
 
         bridge.on_tick = on_tick
 
-        async def on_event(bridge: RuntimeBridge, name: str, data: str):
+        async def on_event(bridge: RuntimeBridge, name: str, data: dict):
             nonlocal intro_step
             if intro_step == 0:
                 print("Step one, resume the simulation.")

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -36,7 +36,7 @@ class DefaultSagaServerDemo(Demo):
             await bridge.runtime.api.modal(
                 "Welcome to the default SAGA server demo!",
                 "This is the default behavior of the bridge. The SAGA server is generating actions and conversations for the agents in the simulation.",
-                "Continue",
+                ["Continue"],
             )
 
             # pause the simulation to allow the user to see everything.
@@ -56,7 +56,7 @@ class DefaultSagaServerDemo(Demo):
                     await bridge.runtime.api.modal(
                         "Demo Complete",
                         "The default SAGA server demo is complete.",
-                        "Close",
+                        ["Close"],
                     )
                     intro_step += 1
 

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -214,6 +214,23 @@ class OnActionComplete(Demo):
 
         sheriff_id = "wyatt_cooper"
 
+        async def on_ready(bridge) -> bool:
+            await bridge.runtime.api.focus_character(sheriff_id)
+            await bridge.runtime.api.follow_character(sheriff_id, 0.8)
+
+            # Set the sheriff's next action to go to the sheriff's station building to start.
+            # Once the sheriff arrives at the building, the on_action_complete callback will be triggered.
+            action = fable_saga.actions.Action(
+                skill="go_to",
+                parameters={
+                    "destination": "thistle_gulch.sheriff_station_building",
+                    "goal": "The sheriff's default action",
+                },
+            )
+            await bridge.runtime.api.override_character_action(sheriff_id, action)
+            return True
+        bridge.on_ready = on_ready
+
         async def on_action_complete(_, persona_id: str, completed_action: str):
 
             # Return None so all characters other than the sheriff use the generate-actions endpoint instead

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -197,10 +197,15 @@ class OnActionComplete(Demo):
 
     def on_action_complete_demo(self, bridge: RuntimeBridge):
         """
-        TODO
+        When the sheriff's current action completes, the simulation is paused and the user is prompted to enter a new
+        location for him to go. The simulation is then resumed and a custom action using the 'go_to' skill is returned
+        to the Runtime. For a full list of available skills see:
+        https://github.com/fablestudio/thistle-gulch?tab=readme-ov-file#skills-and-actions
 
         API calls:
-            TODO
+            pause()
+            resume()
+            get_character_context()
 
         See the API and Demo source code on Github for more information:
             https://github.com/fablestudio/thistle-gulch/blob/main/python/thistle_gulch/api.py
@@ -236,7 +241,7 @@ class OnActionComplete(Demo):
                 skill="go_to",
                 parameters={
                     "destination": location_id,
-                    "goal": "Visit the first available location",
+                    "goal": "Visit the user-chosen location",
                 },
             )
 

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -1,6 +1,10 @@
+import asyncio.futures
+from typing import Optional
+
 import cattrs
 import fable_saga.actions
 from fable_saga import server as saga_server
+from fable_saga.actions import Action
 from langchain.prompts import PromptTemplate
 
 from thistle_gulch import logger, IncomingRoutes, Route
@@ -214,6 +218,10 @@ class OnActionComplete(Demo):
 
         sheriff_id = "wyatt_cooper"
 
+        location_list = ["sheriff_station_building", "the_saloon", "bank_building"]
+
+        future: asyncio.futures.Future
+
         async def on_ready(bridge) -> bool:
             await bridge.runtime.api.focus_character(sheriff_id)
             await bridge.runtime.api.follow_character(sheriff_id, 0.8)
@@ -223,44 +231,63 @@ class OnActionComplete(Demo):
             action = fable_saga.actions.Action(
                 skill="go_to",
                 parameters={
-                    "destination": "thistle_gulch.sheriff_station_building",
-                    "goal": "The sheriff's default action",
+                    "destination": "thistle_gulch." + location_list[0],
+                    "goal": "Start the sheriff's day at the sheriff's station building",
                 },
             )
+
             await bridge.runtime.api.override_character_action(sheriff_id, action)
             return True
+
         bridge.on_ready = on_ready
 
-        async def on_action_complete(_, persona_id: str, completed_action: str):
+        async def on_action_complete(
+            _, persona_id: str, completed_action: str
+        ) -> Optional[Action]:
 
             # Return None so all characters other than the sheriff use the generate-actions endpoint instead
             if persona_id != sheriff_id:
-                return
+                return None
 
             print(f"\n{persona_id}'s last action was: '{completed_action}'")
 
             # Pause the simulation while we wait for user input
             await bridge.runtime.api.pause()
+            # wait for the future to complete
+            nonlocal future
+            future = asyncio.get_event_loop().create_future()
 
-            print(f"Getting character context for {persona_id}")
-            context = await bridge.runtime.api.get_character_context(persona_id)
-
-            location_id = await choose_from_list(
-                f"Enter a new location id for {persona_id} to go",
-                [loc.name for loc in context.locations],
+            await bridge.runtime.api.modal(
+                "Next GOTO Location",
+                f"The sheriff just completed the action: '{completed_action}'."
+                + "\n"
+                + "Choose the next location for the sheriff to go to.",
+                location_list,
             )
 
+            action = await future
             # Resume the simulation
             await bridge.runtime.api.resume()
-
-            # Return a new action for the character to replace the one that just completed
-            return fable_saga.actions.Action(
-                skill="go_to",
-                parameters={
-                    "destination": location_id,
-                    "goal": "Visit the user-chosen location",
-                },
-            )
+            return action
 
         print("Registering custom on_action_complete callback.")
         bridge.on_action_complete = on_action_complete
+
+        async def on_event(_, name: str, data: dict):
+            nonlocal future
+            # Return a new action for the character to replace the one that just completed
+            if name == "modal-response":
+                choice_idx = data["choice"]
+                choice = location_list[choice_idx]
+
+                future.set_result(
+                    fable_saga.actions.Action(
+                        skill="go_to",
+                        parameters={
+                            "destination": "thistle_gulch." + choice,
+                            "goal": "Visit the user-chosen location",
+                        },
+                    )
+                )
+
+        bridge.on_event = on_event

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -215,16 +215,20 @@ class OnActionComplete(Demo):
             if persona_id != sheriff_id:
                 return
 
+            print(f"\n{persona_id}'s last action was: '{completed_action}'")
+
+            # Pause the simulation while we wait for user input
             await bridge.runtime.api.pause()
 
             print(f"Getting character context for {persona_id}")
             context = await bridge.runtime.api.get_character_context(persona_id)
 
             location_id = await choose_from_list(
-                "Pick a location_id for this persona to go to",
+                f"Enter a new location id for {persona_id} to go",
                 [loc.name for loc in context.locations],
             )
 
+            # Resume the simulation
             await bridge.runtime.api.resume()
 
             # Return a new action for the character to replace the one that just completed

--- a/python/run_demos.py
+++ b/python/run_demos.py
@@ -25,6 +25,7 @@ def main():
         override_actions.PrintActionsAndPickFirstDemo(),
         override_actions.SkipSagaAlwaysDoTheDefaultActionDemo(),
         override_actions.ReplaceContextWithYamlDumpDemo(),
+        override_actions.OnActionComplete(),
         custom_models.UseOllamaDemo(),
         custom_models.UseAnthropic(),
         simulation_commands.SetStartTimeDemo(),

--- a/python/thistle_gulch/__init__.py
+++ b/python/thistle_gulch/__init__.py
@@ -85,7 +85,10 @@ class IncomingRoutes(Enum):
 
     generate_actions = "generate-actions"
     generate_conversations = "generate-conversation"
+    simulation_ready = "simulation-ready"
     simulation_event = "simulation-event"
+    simulation_tick = "simulation-tick"
+    simulation_error = "simulation-error"
 
 
 @define

--- a/python/thistle_gulch/api.py
+++ b/python/thistle_gulch/api.py
@@ -1,4 +1,5 @@
 import typing
+from typing import List
 from datetime import datetime
 
 from . import logger, converter
@@ -256,7 +257,7 @@ class API:
         )
 
     async def modal(
-        self, title: str, message: str, confirm_text: str, pause: bool = True
+        self, title: str, message: str, buttons: List[str], pause: bool = True
     ) -> None:
         """
         Display a modal dialog with a title and message. This is a blocking operation - the simulation will not continue
@@ -275,7 +276,7 @@ class API:
                 "command": "modal",
                 "title": title,
                 "message": message,
-                "confirm_text": confirm_text,
+                "buttons": buttons,
                 "pause": pause,
             },
         )

--- a/python/thistle_gulch/bridge.py
+++ b/python/thistle_gulch/bridge.py
@@ -194,7 +194,7 @@ class OnSimulationEventEndpoint(BaseEndpoint[GenericMessage, GenericMessage]):
             action = await self.bridge.on_action_complete(
                 self.bridge, persona_id, completed_action
             )
-            response_data['action'] = action
+            response_data["action"] = action
 
         # Call the on_event callback if it exists.
         if self.bridge.on_event is not None:


### PR DESCRIPTION
- On action complete demo / callback
- Add an OnSimulationError endpoint that logs the errors by default.
- Add a response message to all simulation events.
- Use simulation event endpoint to call the on_action_complete callback.
- Send a dict to the on_event callback.