### PR TITLE
Sim 2903 action override futures

### DIFF
--- a/python/demos/character_commands.py
+++ b/python/demos/character_commands.py
@@ -257,10 +257,13 @@ class OverrideCharacterAction(Demo):
                 [loc.name for loc in context.world_context.locations],
             )
 
-            action = Action("go_to", {
+            action = Action(
+                "go_to",
+                {
                     "destination": location_id,
                     "goal": "Visit the first available location",
-                })
+                },
+            )
 
             print(f"Overriding action for {persona_id} with {action}")
             await bridge.runtime.api.override_character_action(persona_id, action)
@@ -337,11 +340,14 @@ class RobBankAndArrestCriminal(Demo):
                 name for name in interactable_bank.interactions if "Rob" in name
             )
 
-            action = Action("interact", {
+            action = Action(
+                "interact",
+                {
                     "item_guid": interactable_bank.item_guid,
                     "interaction": rob_bank_interaction_name,
                     "goal": "Steal gold from the bank",
-                })
+                },
+            )
 
             print(f"Force {robber_id} to rob the bank using action:\n{action}")
             await bridge.runtime.api.override_character_action(robber_id, action)
@@ -370,11 +376,14 @@ class RobBankAndArrestCriminal(Demo):
                 name for name in interactable_robber.interactions if "Arrest" in name
             )
 
-            action = Action("interact", {
+            action = Action(
+                "interact",
+                {
                     "item_guid": interactable_robber.item_guid,
                     "interaction": arrest_interaction_name,
                     "goal": "Arrest the bank robber",
-                })
+                },
+            )
 
             print(f"Force {sheriff_id} to arrest {robber_id} using action:\n{action}")
             await bridge.runtime.api.override_character_action(sheriff_id, action)
@@ -439,13 +448,16 @@ class CustomConversation(Demo):
                 },
             ]
 
-            action = Action("converse_with", {
+            action = Action(
+                "converse_with",
+                {
                     "persona_guid": speaker_2_id,  # The conversation companion - in this example speaker_1 is the initiator and speaker_2 is the companion
                     "conversation": conversation,  # If no conversation is provided, one will be generated instead
                     "topic": "the murder last night",
                     "context": "",  # Only required if no conversation is provided
                     "goal": "Discuss the recent murder",
-                })
+                },
+            )
 
             print(f"Starting conversation between {speaker_1_id} and {speaker_2_id}:")
             for turn in conversation:

--- a/python/demos/character_commands.py
+++ b/python/demos/character_commands.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timedelta
+
+from fable_saga.actions import Action
+
 from thistle_gulch.bridge import RuntimeBridge
 from . import Demo, choose_from_list, formatted_input_async
 
@@ -254,13 +257,10 @@ class OverrideCharacterAction(Demo):
                 [loc.name for loc in context.world_context.locations],
             )
 
-            action = {
-                "skill": "go_to",
-                "parameters": {
+            action = Action("go_to", {
                     "destination": location_id,
                     "goal": "Visit the first available location",
-                },
-            }
+                })
 
             print(f"Overriding action for {persona_id} with {action}")
             await bridge.runtime.api.override_character_action(persona_id, action)
@@ -337,14 +337,12 @@ class RobBankAndArrestCriminal(Demo):
                 name for name in interactable_bank.interactions if "Rob" in name
             )
 
-            action = {
-                "skill": "interact",
-                "parameters": {
+            action = Action("interact", {
                     "item_guid": interactable_bank.item_guid,
                     "interaction": rob_bank_interaction_name,
                     "goal": "Steal gold from the bank",
-                },
-            }
+                })
+
             print(f"Force {robber_id} to rob the bank using action:\n{action}")
             await bridge.runtime.api.override_character_action(robber_id, action)
 
@@ -372,14 +370,12 @@ class RobBankAndArrestCriminal(Demo):
                 name for name in interactable_robber.interactions if "Arrest" in name
             )
 
-            action = {
-                "skill": "interact",
-                "parameters": {
+            action = Action("interact", {
                     "item_guid": interactable_robber.item_guid,
                     "interaction": arrest_interaction_name,
                     "goal": "Arrest the bank robber",
-                },
-            }
+                })
+
             print(f"Force {sheriff_id} to arrest {robber_id} using action:\n{action}")
             await bridge.runtime.api.override_character_action(sheriff_id, action)
 
@@ -443,16 +439,13 @@ class CustomConversation(Demo):
                 },
             ]
 
-            action = {
-                "skill": "converse_with",
-                "parameters": {
+            action = Action("converse_with", {
                     "persona_guid": speaker_2_id,  # The conversation companion - in this example speaker_1 is the initiator and speaker_2 is the companion
                     "conversation": conversation,  # If no conversation is provided, one will be generated instead
                     "topic": "the murder last night",
                     "context": "",  # Only required if no conversation is provided
                     "goal": "Discuss the recent murder",
-                },
-            }
+                })
 
             print(f"Starting conversation between {speaker_1_id} and {speaker_2_id}:")
             for turn in conversation:

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -1,5 +1,7 @@
 import datetime
 
+from fable_saga.actions import Action
+
 from . import Demo, RuntimeBridge
 
 
@@ -57,18 +59,45 @@ class DefaultSagaServerDemo(Demo):
             nonlocal intro_step, start_time, processing
             if processing:
                 return
+            intro_step += 1
+            processing = True
 
-            if intro_step == 0:
+            if intro_step == 1:
                 if current_time - start_time > datetime.timedelta(minutes=3):
-                    processing = True
                     future = await bridge.runtime.api.modal(
-                        "Demo Complete",
-                        "The default SAGA server demo is complete.",
-                        ["Close"],
+                        "Meet Blackjack Kane",
+                        "The Saloon Owner and leader of the local criminal gang.",
+                        ["Next"],
                         False,
                     )
                     await future
-                    intro_step += 1
-                    processing = False
+
+            elif intro_step == 2:
+                future = await bridge.runtime.api.override_character_action(
+                    "jack_kane",
+                    Action("wait", {
+                        "time": "3",
+                        "goal": "Wait a beat before starting..",
+                    }))
+                await future
+
+            elif intro_step == 3:
+                future = await bridge.runtime.api.modal(
+                    "The SAGA Server",
+                    "The SAGA server is generating actions and conversations for the agents in the simulation.",
+                    ["Next"],
+                    False,
+                )
+                await future
+
+            elif intro_step == 4:
+                future = await bridge.runtime.api.modal(
+                    "Explore the World",
+                    "See the WIKI for more information on the world and characters.",
+                    ["Done"],
+                    False,
+                )
+                await future
+            processing = False
 
         bridge.on_tick = on_tick

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -24,8 +24,10 @@ class DefaultSagaServerDemo(Demo):
         """
 
         intro_step = 0
+        start_time: datetime.datetime
 
         async def on_ready(bridge: RuntimeBridge) -> bool:
+            nonlocal start_time
 
             # First, we focus on a character to see their details.
             await bridge.runtime.api.focus_character("jack_kane")
@@ -33,40 +35,40 @@ class DefaultSagaServerDemo(Demo):
             # Then we move the camera to follow them.
             await bridge.runtime.api.follow_character("jack_kane", 0.8)
 
-            await bridge.runtime.api.modal(
+            future = await bridge.runtime.api.modal(
                 "Welcome to the default SAGA server demo!",
                 "This is the default behavior of the bridge. The SAGA server is generating actions and conversations for the agents in the simulation.",
                 ["Continue"],
+                False,
             )
+            # Wait for the user to click the continue button.
+            await future
 
-            # pause the simulation to allow the user to see everything.
-            return False
+            # Start the simulation (api.resume() is called automatically returning True).
+            context = await bridge.runtime.api.get_world_context()
+            start_time = datetime.datetime.fromisoformat(context.time)
+            return True
 
         bridge.on_ready = on_ready
-        start_time: datetime.datetime
+
+        processing = False
 
         async def on_tick(bridge: RuntimeBridge, current_time: datetime.datetime):
-            nonlocal intro_step, start_time
-            if intro_step == 1:
-                print("Step two - save the start_time")
-                start_time = current_time
-                intro_step += 1
-            elif intro_step == 2:
-                if current_time - start_time > datetime.timedelta(seconds=10):
-                    await bridge.runtime.api.modal(
+            nonlocal intro_step, start_time, processing
+            if processing:
+                return
+
+            if intro_step == 0:
+                if current_time - start_time > datetime.timedelta(minutes=3):
+                    processing = True
+                    future = await bridge.runtime.api.modal(
                         "Demo Complete",
                         "The default SAGA server demo is complete.",
                         ["Close"],
+                        False,
                     )
+                    await future
                     intro_step += 1
+                    processing = False
 
         bridge.on_tick = on_tick
-
-        async def on_event(bridge: RuntimeBridge, name: str, data: dict):
-            nonlocal intro_step
-            if intro_step == 0:
-                print("Step one, resume the simulation.")
-                await bridge.runtime.api.resume()
-                intro_step += 1
-
-        bridge.on_event = on_event

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -38,6 +38,12 @@ class DefaultSagaServerDemo(Demo):
             # Then we move the camera to follow them.
             await bridge.runtime.api.follow_character("jack_kane", 0.8)
 
+            # Disable all agents that may have been enabled by the runtime args.
+            # This way we can control the flow of the demo.
+            context = await bridge.runtime.api.get_world_context()
+            for persona in context.personas:
+                await bridge.runtime.api.enable_agent(persona.persona_guid, False)
+
             # Create a future that can be awaited until the response is received.
             future = asyncio.get_event_loop().create_future()
             await bridge.runtime.api.modal(

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 
 from fable_saga.actions import Action
@@ -37,11 +38,14 @@ class DefaultSagaServerDemo(Demo):
             # Then we move the camera to follow them.
             await bridge.runtime.api.follow_character("jack_kane", 0.8)
 
-            future = await bridge.runtime.api.modal(
+            # Create a future that can be awaited until the response is received.
+            future = asyncio.get_event_loop().create_future()
+            await bridge.runtime.api.modal(
                 "Welcome to the default SAGA server demo!",
                 "This is the default behavior of the bridge. The SAGA server is generating actions and conversations for the agents in the simulation.",
                 ["Continue"],
                 False,
+                future=future,
             )
             # Wait for the user to click the continue button.
             await future
@@ -64,16 +68,21 @@ class DefaultSagaServerDemo(Demo):
 
             if intro_step == 1:
                 if current_time - start_time > datetime.timedelta(minutes=3):
-                    future = await bridge.runtime.api.modal(
+                    # Create a future that can be awaited until the response is received.
+                    future = asyncio.get_event_loop().create_future()
+                    await bridge.runtime.api.modal(
                         "Meet Blackjack Kane",
                         "The Saloon Owner and leader of the local criminal gang.",
                         ["Next"],
                         False,
+                        future=future,
                     )
                     await future
 
             elif intro_step == 2:
-                future = await bridge.runtime.api.override_character_action(
+                # Create a future that can be awaited until the response is received.
+                future = asyncio.get_event_loop().create_future()
+                await bridge.runtime.api.override_character_action(
                     "jack_kane",
                     Action(
                         "wait",
@@ -82,24 +91,31 @@ class DefaultSagaServerDemo(Demo):
                             "goal": "Wait a beat before starting..",
                         },
                     ),
+                    future=future,
                 )
                 await future
 
             elif intro_step == 3:
-                future = await bridge.runtime.api.modal(
+                # Create a future that can be awaited until the response is received.
+                future = asyncio.get_event_loop().create_future()
+                await bridge.runtime.api.modal(
                     "The SAGA Server",
                     "The SAGA server is generating actions and conversations for the agents in the simulation.",
                     ["Next"],
                     False,
+                    future=future,
                 )
                 await future
 
             elif intro_step == 4:
-                future = await bridge.runtime.api.modal(
+                # Create a future that can be awaited until the response is received.
+                future = asyncio.get_event_loop().create_future()
+                await bridge.runtime.api.modal(
                     "Explore the World",
                     "See the WIKI for more information on the world and characters.",
                     ["Done"],
                     False,
+                    future=future,
                 )
                 await future
             processing = False

--- a/python/demos/default_demos.py
+++ b/python/demos/default_demos.py
@@ -75,10 +75,14 @@ class DefaultSagaServerDemo(Demo):
             elif intro_step == 2:
                 future = await bridge.runtime.api.override_character_action(
                     "jack_kane",
-                    Action("wait", {
-                        "time": "3",
-                        "goal": "Wait a beat before starting..",
-                    }))
+                    Action(
+                        "wait",
+                        {
+                            "time": "3",
+                            "goal": "Wait a beat before starting..",
+                        },
+                    ),
+                )
                 await future
 
             elif intro_step == 3:

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -234,6 +234,8 @@ class OnActionComplete(Demo):
                 },
             )
 
+            # Note: We don't use a future here, because we want to use the on_action_complete callback instead.
+            # If we used a future, then on_action_complete would not be called for this action.
             await bridge.runtime.api.override_character_action(sheriff_id, action)
             return True
 
@@ -249,12 +251,15 @@ class OnActionComplete(Demo):
 
             print(f"\n{persona_id}'s last action was: '{completed_action}'")
 
-            future = await bridge.runtime.api.modal(
+            # Create a future that can be awaited until the response is received.
+            future = asyncio.get_event_loop().create_future()
+            await bridge.runtime.api.modal(
                 "Next GOTO Location",
                 f"The sheriff just completed the action: '{completed_action}'."
                 + "\n"
                 + "Choose the next location for the sheriff to go to.",
                 location_list,
+                future=future,
             )
 
             modal_response = await future

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -262,12 +262,12 @@ class OnActionComplete(Demo):
             choice = location_list[choice_idx]
 
             action = Action(
-                    skill="go_to",
-                    parameters={
-                        "destination": "thistle_gulch." + choice,
-                        "goal": "Visit the user-chosen location",
-                    },
-                )
+                skill="go_to",
+                parameters={
+                    "destination": "thistle_gulch." + choice,
+                    "goal": "Visit the user-chosen location",
+                },
+            )
 
             # Return the new action to the Runtime
             return action

--- a/python/demos/override_actions.py
+++ b/python/demos/override_actions.py
@@ -220,8 +220,6 @@ class OnActionComplete(Demo):
 
         location_list = ["sheriff_station_building", "the_saloon", "bank_building"]
 
-        future: asyncio.futures.Future
-
         async def on_ready(bridge) -> bool:
             await bridge.runtime.api.focus_character(sheriff_id)
             await bridge.runtime.api.follow_character(sheriff_id, 0.8)
@@ -251,13 +249,7 @@ class OnActionComplete(Demo):
 
             print(f"\n{persona_id}'s last action was: '{completed_action}'")
 
-            # Pause the simulation while we wait for user input
-            await bridge.runtime.api.pause()
-            # wait for the future to complete
-            nonlocal future
-            future = asyncio.get_event_loop().create_future()
-
-            await bridge.runtime.api.modal(
+            future = await bridge.runtime.api.modal(
                 "Next GOTO Location",
                 f"The sheriff just completed the action: '{completed_action}'."
                 + "\n"
@@ -265,29 +257,20 @@ class OnActionComplete(Demo):
                 location_list,
             )
 
-            action = await future
-            # Resume the simulation
-            await bridge.runtime.api.resume()
+            modal_response = await future
+            choice_idx = modal_response["choice"]
+            choice = location_list[choice_idx]
+
+            action = Action(
+                    skill="go_to",
+                    parameters={
+                        "destination": "thistle_gulch." + choice,
+                        "goal": "Visit the user-chosen location",
+                    },
+                )
+
+            # Return the new action to the Runtime
             return action
 
         print("Registering custom on_action_complete callback.")
         bridge.on_action_complete = on_action_complete
-
-        async def on_event(_, name: str, data: dict):
-            nonlocal future
-            # Return a new action for the character to replace the one that just completed
-            if name == "modal-response":
-                choice_idx = data["choice"]
-                choice = location_list[choice_idx]
-
-                future.set_result(
-                    fable_saga.actions.Action(
-                        skill="go_to",
-                        parameters={
-                            "destination": "thistle_gulch." + choice,
-                            "goal": "Visit the user-chosen location",
-                        },
-                    )
-                )
-
-        bridge.on_event = on_event

--- a/python/thistle_gulch/api.py
+++ b/python/thistle_gulch/api.py
@@ -175,7 +175,9 @@ class API:
         )
         return context
 
-    async def override_character_action(self, persona_id: str, action: Action) -> asyncio.Future:
+    async def override_character_action(
+        self, persona_id: str, action: Action
+    ) -> asyncio.Future:
         """
         Interrupt the character's current action with the one provided. An action is constructed using one of the
         available skills and sent to the Runtime, which causes the character to immediately stop their current action
@@ -307,4 +309,3 @@ class API:
             future,
         )
         return future
-

--- a/python/thistle_gulch/api.py
+++ b/python/thistle_gulch/api.py
@@ -282,7 +282,12 @@ class API:
         )
 
     async def modal(
-        self, title: str, message: str, buttons: List[str], pause: bool = True, future: Optional[Future] = None
+        self,
+        title: str,
+        message: str,
+        buttons: List[str],
+        pause: bool = True,
+        future: Optional[Future] = None,
     ) -> None:
         """
         Display a modal dialog with a title and message and button options. Modals are useful for getting user input

--- a/python/thistle_gulch/api.py
+++ b/python/thistle_gulch/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import typing
 from typing import List
 from datetime import datetime
@@ -274,7 +275,7 @@ class API:
 
     async def modal(
         self, title: str, message: str, buttons: List[str], pause: bool = True
-    ) -> None:
+    ) -> asyncio.Future:
         """
         Display a modal dialog with a title and message. This is a blocking operation - the simulation will not continue
         until the user dismisses the dialog. Modals are useful for getting user input or displaying important information
@@ -286,6 +287,8 @@ class API:
         logger.debug(
             f"Displaying modal dialog with title: {title} and message: {message}"
         )
+        # Create a future that can be awaited until the response is received.
+        future = asyncio.get_event_loop().create_future()
         await self.runtime.send_message(
             "simulation-command",
             {
@@ -295,4 +298,7 @@ class API:
                 "buttons": buttons,
                 "pause": pause,
             },
+            future,
         )
+        return future
+

--- a/python/thistle_gulch/runtime.py
+++ b/python/thistle_gulch/runtime.py
@@ -70,7 +70,13 @@ class Runtime:
     async def receive_request(self, msg, callback):
         pass
 
-    async def send_message(self, msg_type: str, data: Dict[str, Any], event_future:Optional[asyncio.Future]=None, timeout: int = 5) -> GenericMessage:
+    async def send_message(
+        self,
+        msg_type: str,
+        data: Dict[str, Any],
+        event_future: Optional[asyncio.Future] = None,
+        timeout: int = 5,
+    ) -> GenericMessage:
         """
         Send a request to the runtime.
         :param msg_type: type of message.


### PR DESCRIPTION
Requires related PR in the Runtime https://github.com/fablestudio/metaterra/pull/1515

Automatically provides futures when calling api.modal() and api.override_character_action() so that you can await the futures when they are completed or in the case of modal, you can get the options back. See the demo changes to see how much easier this is now. It eliminates the need for on_event callback when you a driving actions/modals from the API.  These two APIs are probably the only ones that make sense to use this with right now, but similar future APs (where you start something, and want to know when it finishes to do something else), should be pretty straight forward to implement.